### PR TITLE
Compatibility with older python3-nautilus

### DIFF
--- a/data/meld_compare.py
+++ b/data/meld_compare.py
@@ -16,8 +16,9 @@ class MeldExtension(GObject.GObject, Nautilus.MenuProvider):
         else:
             self.left_file = file
 
-    def get_file_items(self, files):
+    def get_file_items(self, *args):
         items = []
+        files = args[-1]
 
         if len(files) == 1:
             file = files[0]


### PR DESCRIPTION
based on https://github.com/nextcloud/desktop/pull/5105, also indicated in the [official migration guide to Nautilus 4.0 of nautilus-python](https://gnome.pages.gitlab.gnome.org/nautilus-python/nautilus-python-migrating-to-4.html).

This would allow people still on old version of ubuntu or a distro base on it (like Pop!_OS for me) to enjoy this wonderful extension.